### PR TITLE
refactor(Context): typo in template

### DIFF
--- a/packages/context/Context.astro
+++ b/packages/context/Context.astro
@@ -8,6 +8,6 @@ export interface Props {
 }
 
 const {contextName, lock, ...props} = Astro.props;
-const htmlSolt = await asyncContext(() => Astro.slots.render('default'), Astro, {name: contextName, lock, context: props});
+const html = await asyncContext(() => Astro.slots.render('default'), Astro, {name: contextName, lock, context: props});
 ---
-<Fragment set:html={htmlSolt} />    
+<Fragment set:html={html} />    


### PR DESCRIPTION
### Description of change

`htmlSlot` was misspelled as `htmlSolt`. I wanted to fix it to `htmlSlot` but figured simply `html` was more accurate as the render method returns an HTML string which is also passed to the `set:html` prop.

### Pull-Request Checklist

- [x] Code is up-to-date with the `main` branch
- ~~This pull request links relevant issues as `Fixes #0000`~~ N/A
- ~~Documentation has been updated to reflect this change~~ N/A
- [x] The new commits follow conventions explained
  in [CONTRIBUTING.md](https://github.com/withastro-utils/utils/blob/master/CONTRIBUTING.md)
